### PR TITLE
force return value for Get-Artifacts into array

### DIFF
--- a/Tasks/ReleaseTrigger/ReleaseTrigger.ps1
+++ b/Tasks/ReleaseTrigger/ReleaseTrigger.ps1
@@ -200,7 +200,7 @@ if($definition -eq $null -or $definition -is [array]) {
 	Write-Error "Cannot find Release Definition or there are more than one Release Definition with the name."
 }
 
-$artifacts = Get-Artifacts -TfsUri $tfsUri -ReleaseDefinition $definition -BuildDefinitionId $buildDefinitionId
+$artifacts = @(Get-Artifacts -TfsUri $tfsUri -ReleaseDefinition $definition -BuildDefinitionId $buildDefinitionId)
 $release = TriggerRelease -TfsUri $tfsUri -ReleaseDefinition $definition -Artifacts $artifacts
 
 Write-Verbose "Leaving script ReleaseTrigger.ps1"


### PR DESCRIPTION
when there is only one artifact, Get-Artifacts returns just a single object, instead of an array with one object, causing the request json to be invalid. wrapping the function call in @() forces the return value into an array