### PR TITLE
On-premise compatibility and bugfix for basic authentication

### DIFF
--- a/Tasks/ReleaseTrigger/task.json
+++ b/Tasks/ReleaseTrigger/task.json
@@ -10,7 +10,7 @@
 	"version": {
 		"Major": 0,
 		"Minor": 1,
-		"Patch": 1
+		"Patch": 2
 	},
 	"minimumAgentVersion": "1.95.0",
 	"inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
 	"manifestVersion": 1,
 	"id": "vsts-trigger",
 	"name": "VSTS Trigger",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"publisher": "sergiibomko",
 	"public": true,
 	"targets": [


### PR DESCRIPTION
One change to add compability with on-premise installations and one bugfix in case basic authentication instead of personal access token is used.
In Detail, the following was changed:
1. Added on-premise detection for use with on-premise TFS/DevOps server (so TFS-Uri won't be changed accordingly). For this we use a regular expression that checks if the server domain ends with ".visualstudio.com/".
2. Bugfix: Username variable is called "username", not "user", which won't be a problem with personal access tokens, but will be a problem with basic authentication user/password combination. This has been fixed now.
3. Raised version of build step and extension.